### PR TITLE
ci/node24 actions and publish fix

### DIFF
--- a/.github/workflows/_build-binaries.yml
+++ b/.github/workflows/_build-binaries.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       VHRN_BUILD_VERSION: ${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Rust (latest stable)
         run: |
           rustup update stable
@@ -62,7 +62,7 @@ jobs:
         run: |
           mkdir -p dist
           cp "target/${{ matrix.target }}/release/vhrn" "dist/${{ matrix.asset }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: dist/${{ matrix.asset }}

--- a/.github/workflows/_build-images.yml
+++ b/.github/workflows/_build-images.yml
@@ -42,17 +42,17 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
       - if: ${{ inputs.push }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/vhrn-base
           tags: |
@@ -64,7 +64,7 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.flavor == 'release' }}
             type=raw,value=${{ inputs.extra_tag }},enable=${{ inputs.extra_tag != '' }}
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: image/base
           platforms: linux/amd64,linux/arm64
@@ -76,17 +76,17 @@ jobs:
     if: ${{ inputs.components == 'all' || inputs.components == 'runtime' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
       - if: ${{ inputs.push }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/vhrn-proxy
           tags: |
@@ -97,7 +97,7 @@ jobs:
             type=ref,event=tag,enable=${{ inputs.flavor == 'release' }}
             type=raw,value=latest,enable=${{ inputs.flavor == 'release' }}
             type=raw,value=${{ inputs.extra_tag }},enable=${{ inputs.extra_tag != '' }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: proxy
           platforms: linux/amd64,linux/arm64
@@ -118,10 +118,10 @@ jobs:
           - harness: claude
             version_cmd: claude --version
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -187,7 +187,7 @@ jobs:
 
       - id: meta
         if: ${{ steps.base.outputs.skip != 'true' && steps.exists.outputs.skip != 'true' }}
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/vhrn-${{ matrix.harness }}
           # Harness tags are the agent's version, not vhrn's vX.Y.Z. The canonical
@@ -207,7 +207,7 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ steps.probe.outputs.version }}
       - if: ${{ steps.base.outputs.skip != 'true' && steps.exists.outputs.skip != 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: image/${{ matrix.harness }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ inputs.run_rust }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Rust (latest stable)
         run: |
           rustup update stable
@@ -37,8 +37,8 @@ jobs:
     if: ${{ inputs.run_proxy }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: proxy/go.mod
       - name: Vet and test
@@ -52,5 +52,5 @@ jobs:
     if: ${{ inputs.run_scripts }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: shellcheck pages/install.sh image/base/entrypoint.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       scripts: ${{ steps.filter.outputs.scripts }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -68,7 +68,7 @@ jobs:
     if: ${{ needs.changes.outputs.workflows == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download actionlint
         id: get
         run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
+          pattern: vhrn-*
           merge-multiple: true
       - name: Checksums
         working-directory: dist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       image_tag: ${{ steps.v.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: v
         run: |
           base=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: vhrn-*

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,10 +29,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v5
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: pages
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
+          pattern: vhrn-*
           merge-multiple: true
       - name: Checksums
         working-directory: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tag must match Cargo.toml version
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: vhrn-*


### PR DESCRIPTION
- **ci: publish only the binary artifacts, not build records**
- **ci: bump actions to the node24 runtime**
