### PR TITLE
security: remove .vhrn.toml from the project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,12 @@ Core behavioral invariants — keep these intact:
   only the agent tag the run path resolves from. `vhrn update` re-pulls a floating install; a
   daily `harness-images.yml` cron rebuilds a harness when its agent updates — both independent
   of a CLI release.
-- **Config precedence: flags > `./.vhrn.toml` > `~/.config/vhrn/config.toml` > defaults**
-  (`src/config.rs`, `toml` crate). `blocked_dirs` matches the resolved cwd **exactly** (not
-  subtree), default `["~","/"]`. `toolchains.tools` resolves to a content-addressed derived
-  image (`vhrn-<h>-tc-<hash>`, `FROM` the harness image + `mise use -g`), cached by tag.
+- **Config precedence: flags > `~/.config/vhrn/config.toml` > defaults** (`src/config.rs`,
+  `toml` crate). Config is **host-owned only** — nothing is read from the project directory, so
+  repo content can never configure the jail. `blocked_dirs` matches the resolved cwd
+  **exactly** (not subtree), default `["~","/"]`. `toolchains.tools` resolves to a
+  content-addressed derived image (`vhrn-<h>-tc-<hash>`, `FROM` the harness image +
+  `mise use -g`), cached by tag.
 - **Shell aliases and the installed registry are host state.** `install`/`uninstall` mutate
   `~/.config/vhrn/installed` and regenerate reversible marker-delimited alias blocks in
   bash/zsh/fish rc files (existing files + the current shell's). `command <name>`/`\<name>`

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Wrapper flags (`--open-net`, `--allow`) go after the harness name, before the ag
 
 ## Configuration
 
-Optional TOML, global then per-project. Precedence: CLI flags > `./.vhrn.toml` >
-`~/.config/vhrn/config.toml` > built-in defaults.
+Optional TOML in `~/.config/vhrn/config.toml`. Precedence: CLI flags >
+`~/.config/vhrn/config.toml` > built-in defaults. Config is host-owned only — vhrn reads
+nothing from the project directory, so a cloned repo can never reconfigure the jail.
 
 ```toml
 [run]

--- a/docs/plans/per-project-config.md
+++ b/docs/plans/per-project-config.md
@@ -1,0 +1,74 @@
+# Host-owned per-project configuration
+
+Status: **design sketch, not built.** Written alongside the removal of the `./.vhrn.toml`
+project config layer (a sandbox-escape vector — repo content configuring the jail). This is
+the sanctioned way per-project settings come back: keyed off the user's own global config,
+never a file inside the project.
+
+## Why not just keep `./.vhrn.toml`
+
+Because it is read host-side, before the container launches, a `.vhrn.toml` committed to a
+repository is trusted and obeyed the first time the user runs `vhrn <harness>` in it — so a
+clone can disable the egress guard or widen the persistent allowlist. Per-project
+configuration is a legitimate need (one project wants Go, another wants an extra egress
+domain), but the *source* of that configuration must be a file the user controls, not the
+sandboxed repository.
+
+## Design
+
+Per-project overrides live in a keyed table inside `~/.config/vhrn/config.toml`, addressed by
+the **canonicalized absolute project path** — the same key shape `blocked_dirs` already
+matches against and `history_key` already derives:
+
+```toml
+# ~/.config/vhrn/config.toml — host-owned, outside any repo
+
+[net]
+mode = "enforce"                       # global default for every project
+
+[project."/Users/me/work/payments"]
+toolchains.tools = ["go@1.26"]
+net.allow = ["proxy.golang.org"]       # this project only
+
+[project."/Users/me/oss/ffmpeg"]
+net.mode = "report"
+```
+
+Precedence, unchanged in spirit — every layer host-owned:
+
+```
+CLI flags  >  [project."<cwd>"]  >  top-level keys  >  built-in defaults
+```
+
+Matching is exact on the resolved cwd (`std::fs::canonicalize`), never subtree, so a parent
+project's block does not silently apply to a nested checkout.
+
+## What it may set
+
+The existing `RunConfig` / `ToolchainsConfig` / `NetConfig` fields, scoped to the project:
+`toolchains.tools`, `net.allow`, `net.mode`, `run.blocked_dirs`. Same expressiveness the old
+project layer had — with the trust properties inverted, because the file lives where only the
+user can write it.
+
+## Security property
+
+vhrn reads **nothing** from the project directory to configure itself. The project is mounted
+into the jail and read by the agent *inside* the boundary; it is never an input to how the
+boundary is built. A hostile clone cannot reach any config vhrn acts on.
+
+## Sketch of the implementation
+
+- Extend `Config` with an internal `projects: Map<String, Overrides>` deserialized from the
+  `[project."…"]` tables; keep the public fields as the resolved result.
+- `load_config` gains no new file source — it still reads only `config_dir/config.toml`. After
+  the base merge, if a `[project."<canonical cwd>"]` block matches, overlay it. The cwd is
+  passed in from the run path (which already canonicalizes it), so `config.rs` still never
+  touches the project directory itself.
+- Unit-testable as a pure `(toml, cwd) -> Config` merge, like the current layering.
+
+## Open questions
+
+- Whether `[project]` blocks should support `~` expansion in the key, or require absolute
+  canonical paths only (leaning: canonical only, to match `blocked_dirs` resolution).
+- Whether a glob/prefix form (`[project."/Users/me/oss/*"]`) is worth it, or whether exact
+  match keeps the model simple and auditable (leaning: exact only for v1).

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -33,7 +33,7 @@ Procedures for cutting releases and refreshing images. All driven from
 `0.MINOR.PATCH`; the leading zero stays until 1.0.
 
 - **Minor** if a user must change something they wrote or typed: a renamed or removed flag
-  or subcommand, a `.vhrn.toml` key, a state-file format, or what an image tag means.
+  or subcommand, a `config.toml` key, a state-file format, or what an image tag means.
 - **Patch** otherwise: fixes, additive flags, new allowlist domains, base tooling, docs.
 
 ## Refresh a harness image

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
-//! Merged vhrn configuration. Precedence is project `.vhrn.toml` over global
-//! `config.toml` over built-in defaults (CLI flags win over all of it, applied in
-//! the run path). Each optional field is an `Option` so an unset key falls through
-//! to a lower-precedence layer.
+//! Merged vhrn configuration. Precedence is CLI flags over the global `config.toml`
+//! (under `~/.config/vhrn`) over built-in defaults (flags applied in the run path).
+//! Config is host-owned only — nothing is read from the project directory, so a cloned
+//! repo can never configure the jail. Each optional field is an `Option` so an unset
+//! key falls through to a lower-precedence layer.
 
 use std::path::Path;
 
@@ -75,16 +76,15 @@ fn merge_config(base: Config, over: Config) -> Config {
     out
 }
 
-/// Read and merge the config layers in precedence order — built-in defaults, then
-/// the global `config.toml` under `config_dir`, then the project's `.vhrn.toml`.
-/// Missing files are not an error; a malformed one is. `config_dir` is injected (the
-/// caller resolves it from XDG) so this is testable without touching process env.
-pub(crate) fn load_config(config_dir: &Path, project: &Path) -> Result<Config> {
+/// Read the global config: built-in defaults overlaid with `config.toml` under
+/// `config_dir`. A missing file is not an error; a malformed one is. `config_dir` is
+/// injected (the caller resolves it from XDG) so this is testable without touching process
+/// env. Nothing is read from the project directory — config is host-owned, so repo content
+/// cannot configure the jail.
+pub(crate) fn load_config(config_dir: &Path) -> Result<Config> {
     let mut cfg = default_config();
-    for path in [config_dir.join("config.toml"), project.join(".vhrn.toml")] {
-        if let Some(c) = read_config_file(&path)? {
-            cfg = merge_config(cfg, c);
-        }
+    if let Some(c) = read_config_file(&config_dir.join("config.toml"))? {
+        cfg = merge_config(cfg, c);
     }
     Ok(cfg)
 }
@@ -170,40 +170,34 @@ mod tests {
 
     #[test]
     fn load_config_no_files_yields_defaults() {
-        let cfg = load_config(&temp_dir(), &temp_dir()).unwrap();
+        let cfg = load_config(&temp_dir()).unwrap();
         assert_eq!(cfg, default_config());
     }
 
     #[test]
-    fn load_config_precedence() {
+    fn load_config_global_over_defaults() {
         let config_dir = temp_dir();
         std::fs::write(
             config_dir.join("config.toml"),
             "[toolchains]\ntools = [\"go@1.26\"]\n[net]\nmode = \"report\"\nallow = [\"global.example\"]\n",
         )
         .unwrap();
-        let project = temp_dir();
-        std::fs::write(
-            project.join(".vhrn.toml"),
-            "[net]\nallow = [\"project.example\"]\n",
-        )
-        .unwrap();
 
-        let cfg = load_config(&config_dir, &project).unwrap();
-        assert_eq!(cfg.net.allow, Some(vec!["project.example".to_string()])); // project overrides
-        assert_eq!(cfg.net.mode, Some("report".to_string())); // inherited from global
+        let cfg = load_config(&config_dir).unwrap();
+        assert_eq!(cfg.net.allow, Some(vec!["global.example".to_string()])); // from global config
+        assert_eq!(cfg.net.mode, Some("report".to_string()));
         assert_eq!(cfg.toolchains.tools, Some(vec!["go@1.26".to_string()]));
         assert_eq!(
             cfg.run.blocked_dirs,
             Some(vec!["~".to_string(), "/".to_string()])
-        ); // default
+        ); // unset key falls through to the default
     }
 
     #[test]
     fn load_config_malformed_is_error() {
-        let project = temp_dir();
-        std::fs::write(project.join(".vhrn.toml"), "this is = not valid = toml").unwrap();
-        assert!(load_config(&temp_dir(), &project).is_err());
+        let config_dir = temp_dir();
+        std::fs::write(config_dir.join("config.toml"), "this is = not valid = toml").unwrap();
+        assert!(load_config(&config_dir).is_err());
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -49,8 +49,8 @@ pub(crate) fn vhrn_cache(home: &Path) -> PathBuf {
     vhrn_cache_from(home, std::env::var("XDG_CACHE_HOME").ok().as_deref())
 }
 
-/// Whether `name` is an executable on `$PATH` (approximates exec.LookPath): a file
-/// with any execute bit set in some PATH directory.
+/// Whether `name` is an executable on `$PATH`: a file with any execute bit set in some
+/// PATH directory.
 pub(crate) fn look_path(name: &str) -> bool {
     use std::os::unix::fs::PermissionsExt;
     let Some(paths) = std::env::var_os("PATH") else {

--- a/src/run.rs
+++ b/src/run.rs
@@ -326,7 +326,7 @@ fn prepare_container(h: &Harness) -> Result<ContainerConfig> {
 
     // Config first: a blocked cwd must abort before any host-side work.
     let config_dir_host = crate::shell::vhrn_config_dir(&home);
-    let conf = crate::config::load_config(&config_dir_host, &project)?;
+    let conf = crate::config::load_config(&config_dir_host)?;
     crate::config::check_blocked_dir(
         &project_s,
         &home.to_string_lossy(),


### PR DESCRIPTION
This was a stray artifact generated from the go migration. The intended purpose of .vhrn.toml was to provide per project settings in the project itself. Triggering vhrn <harness> in a project that had the toml file would apply settings to the container itself. This is a terrible design because a project can have a .vhrn.toml inside it that disables settings without the host ever knowing. Project level overrides should be in the user's config.toml not in the project