### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to vhrn are recorded here. The format follows
 
 ## Unreleased
 
+## 0.2.0 - 2026-07-24
+
+### Security
+
+- Remove the project-level `./.vhrn.toml` config layer, a sandbox-escape vector. It was read
+  host-side before the container launched, so a `.vhrn.toml` committed to any repository was
+  trusted and obeyed on the first `vhrn <harness>` run in it — able to disable the egress guard
+  (`net.mode = "open"`) or permanently widen the host allowlist (`net.allow`). `git clone
+  <repo> && vhrn <harness>` was the whole exploit.
+
+### Changed
+
+- Configuration is host-owned only. Precedence is now flags > `~/.config/vhrn/config.toml` >
+  defaults; nothing is read from the project directory. Per-project settings that lived in
+  `./.vhrn.toml` (`toolchains.tools`, `net.allow`, `net.mode`, `run.blocked_dirs`) must move
+  into the global config — a host-owned `[project."<path>"]` form is planned (see
+  `docs/plans/per-project-config.md`).
+
 ## 0.1.0 - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vhrn"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhrn"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 description = "Run coding agents in a filesystem- and network-jailed container"


### PR DESCRIPTION
Cuts **v0.2.0**.

The substance is #23 — removal of the project-level `./.vhrn.toml` config layer, a sandbox-escape vector where a cloned repo could reconfigure its own jail (disable the egress guard, permanently widen the host allowlist).

**Why a minor (0.2.0) not a patch:** per `docs/runbooks/release.md`, removing a config surface a user could have written is a Minor bump. Per-project settings must move from `./.vhrn.toml` into `~/.config/vhrn/config.toml`.

Changes here:
- `CHANGELOG.md` — promote Unreleased → `0.2.0` (Security + Changed)
- `Cargo.toml` / `Cargo.lock` — `0.1.0` → `0.2.0`

After merge: tag `v0.2.0` on the merge commit and push it, then approve the `release` environment in Actions to publish images + the GitHub Release.