### PR TITLE
cli: check the registry before re-pulling on update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,11 @@ Core behavioral invariants — keep these intact:
   proxy (`proxy_tag` derives it: a nightly CLI → nightly proxy, a `vX.Y.Z` CLI → its own tag).
   Override the registry with `VHRN_REGISTRY`. `--local` uses `make`-built images (version
   `local`). The installed registry (`~/.config/vhrn/installed`, `name <tag>` per line) records
-  only the agent tag the run path resolves from. `vhrn update` re-pulls a floating install; a
-  daily `harness-images.yml` cron rebuilds a harness when its agent updates — both independent
-  of a CLI release.
+  only the agent tag the run path resolves from. `vhrn update` queries the registry (OCI
+  tags-list / manifest digest over the anonymous bearer-challenge flow, `src/registry.rs`) and
+  re-pulls a floating install only when a newer agent is published — never pulling just to
+  diff; an unreachable registry is a hard error, not a blind pull. A daily `harness-images.yml`
+  cron rebuilds a harness when its agent updates — both independent of a CLI release.
 - **Config precedence: flags > `~/.config/vhrn/config.toml` > defaults** (`src/config.rs`,
   `toml` crate). Config is **host-owned only** — nothing is read from the project directory, so
   repo content can never configure the jail. `blocked_dirs` matches the resolved cwd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `vhrn update` now asks the registry whether a newer agent is published and re-pulls only when
+  one is, instead of re-pulling every time and diffing image digests to find out. An up-to-date
+  harness reports `already current` with no pull (and no `pulling …` noise). The check is a
+  metadata-only query over the standard OCI bearer-challenge flow, so it works on any registry,
+  not just GHCR. A registry that can't be reached is now a hard error (non-zero exit) rather
+  than a blind re-pull — you can't update an offline machine.
+
 ### Fixed
 
 - GitHub Release notes are taken from the release's `CHANGELOG.md` section rather than

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,12 +24,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -45,6 +73,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -80,7 +117,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -94,6 +158,22 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -154,12 +234,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,6 +257,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -208,6 +304,55 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "serde"
@@ -282,6 +427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,10 +453,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -451,6 +614,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +673,22 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "ureq",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -476,6 +696,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -487,10 +716,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ signal-hook = "0.4.4"
 toml = "1.1.3"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+ureq = "3.3.0"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ vhrn install <harness>
 
 Restart your shell to pick up the alias. Pin or roll back a harness to a specific agent
 version with `@` (`vhrn install claude@2.1.30`, or `@nightly` for the latest master build),
-and `vhrn update` re-pulls installed harnesses to the newest agent. `VHRN_VERSION` pins the
-CLI installer.
+and `vhrn update` re-pulls installed harnesses only when the registry has a newer agent.
+`VHRN_VERSION` pins the CLI installer.
 
 ## Usage
 
@@ -34,7 +34,7 @@ vhrn <harness> --open-net        # drop the guard for this session (all egress)
 vhrn <harness> -- --help         # harness's own help (-- stops wrapper flag parsing)
 
 vhrn list                        # known + installed harnesses
-vhrn update [<harness>]          # re-pull installed harnesses to the newest agent
+vhrn update [<harness>]          # re-pull installed harnesses when a newer agent is published
 vhrn uninstall <harness>         # drop the alias/registry entry (--image also deletes the image)
 ```
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,4 @@
 # syn is pulled at 2.x by tracing-attributes and 3.x by serde_derive.
-allowed-duplicate-crates = ["syn"]
+# windows-sys is pulled at two versions through ureq's TLS stack (Windows-only, unreachable
+# on our targets).
+allowed-duplicate-crates = ["syn", "windows-sys"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ Usage:
   vhrn uninstall <harness>                remove the alias/registry entry (--image drops the image)
   vhrn <harness> [flags] [-- ] [args...]  run a harness in the container
   vhrn list                               show known and installed harnesses
-  vhrn update [<harness>...]              re-pull installed harnesses to the latest agent
+  vhrn update [<harness>...]              re-pull installed harnesses when a newer agent exists
   vhrn net <subcommand>                   manage the egress policy
   vhrn help                               show this help
   vhrn --version                          print the version
@@ -259,57 +259,94 @@ fn run_update(args: &[String]) -> i32 {
         }
     };
     let registry = crate::image::registry_base();
+    let mut ok = true;
     for ih in &targets {
-        update_one(&engine, &registry, ih);
+        ok &= update_one(&engine, &registry, ih);
     }
-    0
+    i32::from(!ok)
 }
 
 /// Update one installed harness in place, printing a one-line result. Pinned/local installs
-/// are reported and skipped; a floating one re-pulls and reports the version label move —
-/// no container is started to name the version.
-fn update_one(engine: &str, registry: &str, ih: &crate::shell::InstalledHarness) {
+/// are reported and skipped; a floating install is checked against the registry and pulled
+/// only when it is actually behind — never pulled just to discover it is already current.
+/// Returns false when the check couldn't run (registry unreachable) or the pull failed, so
+/// the caller exits non-zero.
+fn update_one(engine: &str, registry: &str, ih: &crate::shell::InstalledHarness) -> bool {
     let (name, version) = (&ih.name, &ih.version);
     let Some(h) = crate::harness::lookup_harness(name) else {
         warn!("{name:?} is not a known harness; skipping");
-        return;
+        return true;
     };
     if version == crate::image::LOCAL_VERSION {
         println!("  {name:<12} local build — rebuild with `make -C image`");
-        return;
+        return true;
     }
     if version != "latest" && version != "nightly" {
         println!("  {name:<12} pinned at {version} — `vhrn install {name}` to return to latest");
-        return;
+        return true;
     }
 
     let harness_img = crate::image::harness_image_ref(registry, &h, version);
-    let id_before = crate::image::image_id(engine, &harness_img);
-    let ver_before = crate::image::image_version_label(engine, &harness_img);
 
-    if let Err(e) = crate::image::provision_images(engine, registry, &h, version) {
-        error!("  {name:<12} update failed: {e}");
-        return;
-    }
-
-    let id_after = crate::image::image_id(engine, &harness_img);
-    let ver_after = crate::image::image_version_label(engine, &harness_img);
-
-    // An unmoved digest means the re-pull brought nothing new.
-    if id_before.is_some() && id_before == id_after {
-        if let Some(v) = ver_after {
-            println!("  {name:<12} {v} — already current");
-        } else {
-            println!("  {name:<12} already current ({version})");
+    // Nightly has no X.Y.Z tag, so compare the published :nightly digest to the local one.
+    if version == "nightly" {
+        let Some(remote) = crate::registry::remote_manifest_digest(registry, &h.image, "nightly")
+        else {
+            report_unreachable(name, registry);
+            return false;
+        };
+        if crate::image::image_manifest_digest(engine, &harness_img).as_deref() == Some(&*remote) {
+            println!("  {name:<12} nightly — already current");
+            return true;
         }
-        return;
+        return pull_update(engine, registry, &h, version, || {
+            println!("  {name:<12} nightly updated");
+        });
     }
-    match (ver_before, ver_after) {
-        (Some(b), Some(a)) if b == a => println!("  {name:<12} {a} — already current"),
-        (Some(b), Some(a)) => println!("  {name:<12} {b} → {a}"),
-        (_, Some(a)) => println!("  {name:<12} now {a}"),
-        (_, None) => println!("  {name:<12} updated ({version})"),
+
+    // Latest: pull only if the newest published version is strictly ahead of the installed one.
+    let Some(newest) = crate::registry::newest_published_version(registry, &h.image) else {
+        report_unreachable(name, registry);
+        return false;
+    };
+    match crate::image::image_version_label(engine, &harness_img).as_deref() {
+        Some(cur) if crate::registry::update_available(&newest, cur) == Some(false) => {
+            println!("  {name:<12} {cur} — already current");
+            true
+        }
+        Some(cur) => pull_update(engine, registry, &h, version, || {
+            println!("  {name:<12} {cur} → {newest}");
+        }),
+        // No readable local version: pull to the newest and name it.
+        None => pull_update(engine, registry, &h, version, || {
+            println!("  {name:<12} now {newest}");
+        }),
     }
+}
+
+/// Pull the harness (and its matching proxy) for an available update, then report it via
+/// `on_success`. Returns false if the pull failed.
+fn pull_update(
+    engine: &str,
+    registry: &str,
+    h: &crate::harness::Harness,
+    version: &str,
+    on_success: impl FnOnce(),
+) -> bool {
+    if let Err(e) = crate::image::provision_images(engine, registry, h, version) {
+        error!("  {:<12} update failed: {e}", h.name);
+        return false;
+    }
+    on_success();
+    true
+}
+
+/// A registry install we couldn't check (offline / registry down / non-OCI). Emits a
+/// guaranteed user-facing line so the failure is visible even if logging is redirected.
+fn report_unreachable(name: &str, registry: &str) {
+    eprintln!("vhrn: cannot check {name} for updates — registry {registry} unreachable");
+    // TODO: once tracing is hardened (e.g. a file sink), also error!(<underlying cause>) so the
+    // network error is recorded to the log without duplicating this line on stderr today.
 }
 
 /// Drop a harness from the installed registry and regenerate the shell aliases so its

--- a/src/image.rs
+++ b/src/image.rs
@@ -223,6 +223,39 @@ fn first_sha256(s: &str) -> Option<String> {
     (hex.len() >= 12).then(|| format!("sha256:{hex}"))
 }
 
+/// The registry manifest digest (`sha256:…`) a local image was pulled at — the same digest
+/// the tag resolves to in the registry, for the nightly digest check. This is *not* `image_id`:
+/// Docker's `.Id` is the config digest and would never match a tag's `Docker-Content-Digest`,
+/// so Docker reads `RepoDigests[0]` (`repo@sha256:…`) instead; Apple `container` already
+/// exposes the manifest digest as inspect's first `sha256:` (`configuration.descriptor.digest`).
+/// None if the image is absent or was never pulled from a registry (empty `RepoDigests`).
+pub(crate) fn image_manifest_digest(engine: &str, image: &str) -> Option<String> {
+    if engine == "docker" {
+        let out = Command::new("docker")
+            .args([
+                "image",
+                "inspect",
+                "-f",
+                "{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}",
+                image,
+            ])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        return first_sha256(&String::from_utf8_lossy(&out.stdout));
+    }
+    let out = Command::new("container")
+        .args(["image", "inspect", image])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    first_sha256(&String::from_utf8_lossy(&out.stdout))
+}
+
 /// The OCI label CI stamps the agent version into; the host reads it back to name a
 /// harness image's version without running it.
 const VERSION_LABEL: &str = "org.opencontainers.image.version";
@@ -491,6 +524,11 @@ mod tests {
         assert_eq!(
             first_sha256(r#"{"Id":"sha256:abcdef0123456789"}"#),
             Some("sha256:abcdef0123456789".to_string())
+        );
+        // A docker RepoDigests entry — what image_manifest_digest reads on the nightly path.
+        assert_eq!(
+            first_sha256("ghcr.io/aravind-n/vhrn-claude@sha256:c0a8ccd395b3848a"),
+            Some("sha256:c0a8ccd395b3848a".to_string())
         );
         assert_eq!(first_sha256("no digest here"), None);
         assert_eq!(first_sha256("sha256:abc"), None); // fewer than 12 hex chars

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod image;
 mod logging;
 mod net;
 mod persist;
+mod registry;
 mod run;
 mod shell;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,374 @@
+//! Registry queries for `vhrn update`: ask an OCI registry what is published so the CLI can
+//! decide whether to pull, instead of pulling to find out. Uses the standard bearer-challenge
+//! flow (GET, on 401 parse `WWW-Authenticate`, fetch a token, retry), so it is
+//! registry-agnostic — GHCR, Docker Hub, any OCI registry. Network reads are best-effort:
+//! any failure returns `None` and the caller reports the harness as uncheckable.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// A registry manifest `Accept` header covering the multi-arch index and single manifest
+/// media types, so `Docker-Content-Digest` names the same digest the engine stores locally.
+const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.index.v1+json, \
+     application/vnd.docker.distribution.manifest.list.v2+json, \
+     application/vnd.oci.image.manifest.v1+json, \
+     application/vnd.docker.distribution.manifest.v2+json";
+
+/// A parsed `WWW-Authenticate: Bearer realm=…,service=…,scope=…` challenge.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct BearerChallenge {
+    pub realm: String,
+    pub service: String,
+    pub scope: String,
+}
+
+/// Parse the `Bearer realm="…",service="…",scope="…"` header a registry returns on a 401.
+/// Reads each quoted value by name so an embedded comma (e.g. `scope="…:pull,push"`) is safe.
+/// Needs a realm; service/scope default to empty.
+pub(crate) fn parse_www_authenticate(header: &str) -> Option<BearerChallenge> {
+    // The auth scheme is case-insensitive (RFC 7235), so don't insist on "Bearer".
+    let scheme_is_bearer = header
+        .trim_start()
+        .get(..6)
+        .is_some_and(|s| s.eq_ignore_ascii_case("bearer"));
+    if !scheme_is_bearer {
+        return None;
+    }
+    Some(BearerChallenge {
+        realm: quoted_value(header, "realm")?,
+        service: quoted_value(header, "service").unwrap_or_default(),
+        scope: quoted_value(header, "scope").unwrap_or_default(),
+    })
+}
+
+/// The value of a `key="value"` pair in a header, or `None` if the key is absent.
+fn quoted_value(header: &str, key: &str) -> Option<String> {
+    let needle = format!("{key}=\"");
+    let start = header.find(&needle)? + needle.len();
+    let end = header[start..].find('"')?;
+    Some(header[start..start + end].to_string())
+}
+
+/// The token endpoint for a challenge: `realm?service=…&scope=…` (our pull scopes are already
+/// URL-safe, so no escaping is needed).
+fn token_url(bc: &BearerChallenge) -> String {
+    let mut params = Vec::new();
+    if !bc.service.is_empty() {
+        params.push(format!("service={}", bc.service));
+    }
+    if !bc.scope.is_empty() {
+        params.push(format!("scope={}", bc.scope));
+    }
+    if params.is_empty() {
+        bc.realm.clone()
+    } else {
+        format!("{}?{}", bc.realm, params.join("&"))
+    }
+}
+
+/// Split a registry base like `ghcr.io/aravind-n` into (host, namespace). A base with no `/`
+/// is all host, empty namespace.
+fn split_registry(base: &str) -> (&str, &str) {
+    base.split_once('/').unwrap_or((base, ""))
+}
+
+/// The repository path for `image` on a registry base: `<namespace>/<image>`, or just
+/// `<image>` when the base carries no namespace.
+fn repo_path(base: &str, image: &str) -> String {
+    let (_, ns) = split_registry(base);
+    if ns.is_empty() {
+        image.to_string()
+    } else {
+        format!("{ns}/{image}")
+    }
+}
+
+/// Parse a strict `X.Y.Z` tag into a comparable tuple. Anything with a suffix (`2.1.3-x`),
+/// a moving tag (`nightly`, `latest`), or non-numeric parts is rejected.
+fn parse_semver(tag: &str) -> Option<(u64, u64, u64)> {
+    let mut it = tag.split('.');
+    let major = it.next()?.parse().ok()?;
+    let minor = it.next()?.parse().ok()?;
+    let patch = it.next()?.parse().ok()?;
+    if it.next().is_some() {
+        return None; // more than three components
+    }
+    Some((major, minor, patch))
+}
+
+/// The newest strict-`X.Y.Z` tag in a tag list, returned in its original string form. Tags
+/// that are not strict semver (`latest`, `nightly-…`, `2.1.3-20260101`) are ignored.
+pub(crate) fn newest_semver(tags: &[String]) -> Option<String> {
+    tags.iter()
+        .filter_map(|t| parse_semver(t).map(|v| (v, t)))
+        .max_by_key(|(v, _)| *v)
+        .map(|(_, t)| t.clone())
+}
+
+/// Whether `newest` is a strictly newer version than `installed`. `None` if either is not
+/// strict semver, so the caller can distinguish "can't tell" from "not newer".
+pub(crate) fn update_available(newest: &str, installed: &str) -> Option<bool> {
+    Some(parse_semver(newest)? > parse_semver(installed)?)
+}
+
+// ---- network edge (best-effort; any failure → None) --------------------------------------
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    token: String,
+}
+
+#[derive(Deserialize)]
+struct TagsResponse {
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+/// An agent that surfaces non-2xx as `Ok` (so a 401's challenge header is readable) and caps
+/// each call so a hung registry can't stall the CLI.
+fn http_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .timeout_global(Some(Duration::from_secs(15)))
+        .build()
+        .into()
+}
+
+/// GET `url` doing the OCI bearer-challenge transparently: on a 401, parse the challenge,
+/// fetch a token, and retry once with it. Returns the final response.
+fn get_challenged(
+    agent: &ureq::Agent,
+    url: &str,
+    accept: Option<&str>,
+) -> Option<ureq::http::Response<ureq::Body>> {
+    let mut first = agent.get(url);
+    if let Some(a) = accept {
+        first = first.header("Accept", a);
+    }
+    let resp = first.call().ok()?;
+    if resp.status().as_u16() != 401 {
+        return Some(resp);
+    }
+    let challenge = resp.headers().get("www-authenticate")?.to_str().ok()?;
+    let token = fetch_token(agent, &parse_www_authenticate(challenge)?)?;
+    let mut retry = agent
+        .get(url)
+        .header("Authorization", &format!("Bearer {token}"));
+    if let Some(a) = accept {
+        retry = retry.header("Accept", a);
+    }
+    retry.call().ok()
+}
+
+/// Fetch an anonymous bearer token from the challenge's realm.
+fn fetch_token(agent: &ureq::Agent, bc: &BearerChallenge) -> Option<String> {
+    let mut resp = agent.get(&token_url(bc)).call().ok()?;
+    if resp.status().as_u16() != 200 {
+        return None;
+    }
+    let body = resp.body_mut().read_to_string().ok()?;
+    serde_json::from_str::<TokenResponse>(&body)
+        .ok()
+        .map(|t| t.token)
+}
+
+/// The `rel="next"` target of an OCI pagination `Link` header, resolved to an absolute URL.
+fn link_next(link: Option<&str>, host: &str) -> Option<String> {
+    let link = link?;
+    for part in link.split(',') {
+        if !part.contains("rel=\"next\"") && !part.contains("rel=next") {
+            continue;
+        }
+        let start = part.find('<')? + 1;
+        let end = part[start..].find('>')? + start;
+        let target = &part[start..end];
+        return Some(if target.starts_with("http") {
+            target.to_string()
+        } else {
+            format!("https://{host}{target}")
+        });
+    }
+    None
+}
+
+/// Every tag published for `image` on `registry`, following `Link` pagination (capped).
+fn fetch_tags(registry: &str, image: &str) -> Option<Vec<String>> {
+    let host = split_registry(registry).0;
+    let repo = repo_path(registry, image);
+    let agent = http_agent();
+    let mut url = format!("https://{host}/v2/{repo}/tags/list");
+    let mut all = Vec::new();
+    for _ in 0..50 {
+        let resp = get_challenged(&agent, &url, None)?;
+        if resp.status().as_u16() != 200 {
+            return (!all.is_empty()).then_some(all);
+        }
+        let next = link_next(
+            resp.headers().get("link").and_then(|h| h.to_str().ok()),
+            host,
+        );
+        let body = resp.into_body().read_to_string().ok()?;
+        all.append(&mut serde_json::from_str::<TagsResponse>(&body).ok()?.tags);
+        match next {
+            Some(n) => url = n,
+            None => break,
+        }
+    }
+    Some(all)
+}
+
+/// The newest published strict-`X.Y.Z` version for a harness image, or `None` if the registry
+/// can't be reached or has no semver tag.
+pub(crate) fn newest_published_version(registry: &str, image: &str) -> Option<String> {
+    newest_semver(&fetch_tags(registry, image)?)
+}
+
+/// The manifest digest (`sha256:…`) a tag resolves to in the registry — the same value the
+/// engine stores locally, for the nightly digest comparison. `None` on any failure.
+pub(crate) fn remote_manifest_digest(registry: &str, image: &str, tag: &str) -> Option<String> {
+    let host = split_registry(registry).0;
+    let repo = repo_path(registry, image);
+    let url = format!("https://{host}/v2/{repo}/manifests/{tag}");
+    let resp = get_challenged(&http_agent(), &url, Some(MANIFEST_ACCEPT))?;
+    if resp.status().as_u16() != 200 {
+        return None;
+    }
+    let digest = resp
+        .headers()
+        .get("docker-content-digest")?
+        .to_str()
+        .ok()?
+        .trim()
+        .to_string();
+    digest.starts_with("sha256:").then_some(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The real challenge strings GHCR and Docker Hub return on an unauthenticated /v2 read.
+    #[test]
+    fn parse_challenge_ghcr_and_dockerhub() {
+        let ghcr = parse_www_authenticate(
+            r#"Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:aravind-n/vhrn-claude:pull""#,
+        )
+        .expect("ghcr challenge");
+        assert_eq!(ghcr.realm, "https://ghcr.io/token");
+        assert_eq!(ghcr.service, "ghcr.io");
+        assert_eq!(ghcr.scope, "repository:aravind-n/vhrn-claude:pull");
+
+        let hub = parse_www_authenticate(
+            r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/node:pull""#,
+        )
+        .expect("docker hub challenge");
+        assert_eq!(hub.realm, "https://auth.docker.io/token");
+        assert_eq!(hub.service, "registry.docker.io");
+        assert_eq!(hub.scope, "repository:library/node:pull");
+    }
+
+    #[test]
+    fn parse_challenge_rejects_non_bearer() {
+        assert!(parse_www_authenticate(r#"Basic realm="x""#).is_none());
+        assert!(parse_www_authenticate("Bearer service=\"x\"").is_none()); // no realm
+        // The scheme is case-insensitive (RFC 7235).
+        assert_eq!(
+            parse_www_authenticate(r#"bearer realm="https://r/token""#).map(|c| c.realm),
+            Some("https://r/token".to_string())
+        );
+    }
+
+    #[test]
+    fn token_url_builds_query() {
+        let bc = BearerChallenge {
+            realm: "https://auth.docker.io/token".into(),
+            service: "registry.docker.io".into(),
+            scope: "repository:library/node:pull".into(),
+        };
+        assert_eq!(
+            token_url(&bc),
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull"
+        );
+        // A realm without service/scope stays bare.
+        let bare = BearerChallenge {
+            realm: "https://ghcr.io/token".into(),
+            service: String::new(),
+            scope: String::new(),
+        };
+        assert_eq!(token_url(&bare), "https://ghcr.io/token");
+    }
+
+    #[test]
+    fn repo_path_from_registry_base() {
+        assert_eq!(
+            split_registry("ghcr.io/aravind-n"),
+            ("ghcr.io", "aravind-n")
+        );
+        assert_eq!(
+            repo_path("ghcr.io/aravind-n", "vhrn-claude"),
+            "aravind-n/vhrn-claude"
+        );
+        assert_eq!(
+            repo_path("ghcr.io/org/sub", "vhrn-claude"),
+            "org/sub/vhrn-claude"
+        );
+        // A bare host with no namespace.
+        assert_eq!(repo_path("localhost:5000", "vhrn-claude"), "vhrn-claude");
+    }
+
+    #[test]
+    fn parse_semver_is_strict() {
+        assert_eq!(parse_semver("2.1.218"), Some((2, 1, 218)));
+        assert_eq!(parse_semver("2.1.218-20260724"), None); // dated suffix
+        assert_eq!(parse_semver("nightly"), None);
+        assert_eq!(parse_semver("latest"), None);
+        assert_eq!(parse_semver("2.1"), None); // too few
+        assert_eq!(parse_semver("2.1.3.4"), None); // too many
+        assert_eq!(parse_semver("2.1.x"), None);
+    }
+
+    #[test]
+    fn newest_semver_picks_max_ignoring_non_semver() {
+        let tags: Vec<String> = [
+            "nightly",
+            "2.1.218",
+            "latest",
+            "2.1.218-20260724",
+            "2.10.0",
+            "2.9.9",
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+        assert_eq!(newest_semver(&tags).as_deref(), Some("2.10.0"));
+        assert_eq!(newest_semver(&["nightly".into(), "latest".into()]), None);
+        assert_eq!(newest_semver(&[]), None);
+    }
+
+    #[test]
+    fn update_available_compares_semver() {
+        assert_eq!(update_available("2.1.219", "2.1.218"), Some(true));
+        assert_eq!(update_available("2.1.218", "2.1.218"), Some(false));
+        assert_eq!(update_available("2.1.217", "2.1.218"), Some(false));
+        assert_eq!(update_available("2.2.0", "2.1.999"), Some(true));
+        assert_eq!(update_available("nightly", "2.1.218"), None);
+    }
+
+    #[test]
+    fn link_next_resolves_relative_and_absolute() {
+        assert_eq!(
+            link_next(
+                Some(r#"</v2/x/tags/list?last=z&n=100>; rel="next""#),
+                "ghcr.io"
+            ),
+            Some("https://ghcr.io/v2/x/tags/list?last=z&n=100".into())
+        );
+        assert_eq!(
+            link_next(Some(r#"<https://other/next>; rel="next""#), "ghcr.io"),
+            Some("https://other/next".into())
+        );
+        assert_eq!(link_next(None, "ghcr.io"), None);
+        assert_eq!(link_next(Some("<x>; rel=\"prev\""), "ghcr.io"), None);
+    }
+}


### PR DESCRIPTION
Query the registry and pull only when behind — latest compares the newest published X.Y.Z tag, nightly the remote manifest digest, over the OCI bearer-challenge flow (ureq); an unreachable registry now errors instead of pulling blindly. Updates docs and changelog to match.