### PR TITLE
image: exempt the mounted project from git's ownership check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,10 @@ Core behavioral invariants — keep these intact:
   (`$GH_TOKEN`/`$GITHUB_TOKEN`, else `gh auth token`) and passes it as `GH_TOKEN`; the
   entrypoint runs `gh auth setup-git`. Skips silently without a host gh login; SSH remotes
   stay unauthenticated. The host `~/.gitconfig` is copied into the cache and bind-mounted at
-  `/home/dev/.gitconfig` (a disposable copy — change the host file).
+  `/home/dev/.gitconfig` (a disposable copy — change the host file). The base image also sets
+  `safe.directory = *` in `/etc/gitconfig`: virtiofs reports the mount root's owner
+  inconsistently and would otherwise break git at random — only one project is ever mounted,
+  so it weakens nothing.
 - **Images are pulled from a registry, not built by users.** `vhrn install <harness>[@version]`
   pulls `vhrn-<harness>` at the *agent's* version (default `latest`) plus the `vhrn-proxy`
   matching the **CLI binary's own** version — the proxy rides the CLI's release clock, not the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Release notes are taken from the release's `CHANGELOG.md` section rather than
   auto-generated from merged pull-request titles.
 
+- Git no longer fails intermittently inside the container with `fatal: detected dubious
+  ownership in repository at …`. Apple Container's virtiofs reports the project mount's
+  ownership inconsistently, which tripped git's ownership check at random — hitting the agent's
+  own `git status`/`commit` as readily as a statusline's git segment, which would show, drop,
+  and reappear. The base image now exempts the mounted project. Re-run
+  `vhrn install <harness>` to pick up the rebuilt image.
+
 ## [0.2.0] - 2026-07-24
 
 ### Security

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -75,6 +75,11 @@ RUN groupadd -g "$USER_GID" dev 2>/dev/null || true; \
 # ~/.profile, which the entrypoint sources at runtime — so no per-tool paths live here.
 ENV PATH=/home/dev/.local/bin:$PATH
 
+# virtiofs reports the bind-mount root's owner inconsistently (0:0 one moment, dev the next),
+# which trips git's dubious-ownership check at random. Only the one project is ever mounted,
+# so a blanket exemption weakens nothing. --system: /etc/gitconfig, not the mounted ~/.gitconfig.
+RUN git config --system --add safe.directory '*'
+
 # Entrypoint installs the egress firewall then drops to dev; needs procps for the lock check.
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
virtiofs flaps the mount root's owner between root and dev, so git rejects the worktree at random; only the one project is ever mounted, so a blanket safe.directory weakens nothing.