### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-25
+
 ### Added
 
 - The base image now bundles more of the tools an agent reaches for: gcc/g++
@@ -90,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `toolchains.tools` derived image rebuilds when its harness image updates (the base image
   identity is folded into the toolchain hash), so `vhrn update` no longer keeps the old agent.
 
-[unreleased]: https://github.com/aravind-n/vhrn/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/aravind-n/vhrn/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/aravind-n/vhrn/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/aravind-n/vhrn/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/aravind-n/vhrn/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vhrn"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhrn"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "Run coding agents in a filesystem- and network-jailed container"


### PR DESCRIPTION
Promotes the `Unreleased` changelog section to 0.3.0, bumps `Cargo.toml`, and refreshes `Cargo.lock`.

Minor bump: `[toolchains]` is replaced by `[tools]`, a config key users must change.

Tag `v0.3.0` follows once this lands.