### PR TITLE
cli: back the test temp-dir helper with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +157,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -211,6 +234,12 @@ name = "libc"
 version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -289,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "regex-automata"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,10 +348,23 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -490,6 +538,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -670,6 +731,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "signal-hook",
+ "tempfile",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ toml = "1.1.3"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 ureq = "3.3.0"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,7 +176,8 @@ mod tests {
 
     #[test]
     fn load_config_no_files_yields_defaults() {
-        let cfg = load_config(&temp_dir()).unwrap();
+        let dir = temp_dir();
+        let cfg = load_config(dir.path()).unwrap();
         assert_eq!(cfg, default_config());
     }
 
@@ -184,12 +185,12 @@ mod tests {
     fn load_config_global_over_defaults() {
         let config_dir = temp_dir();
         std::fs::write(
-            config_dir.join("config.toml"),
+            config_dir.path().join("config.toml"),
             "[tools]\napt = [\"ripgrep\"]\nrun = [\"curl https://example.test | sh\"]\n[net]\nmode = \"report\"\nallow = [\"global.example\"]\n",
         )
         .unwrap();
 
-        let cfg = load_config(&config_dir).unwrap();
+        let cfg = load_config(config_dir.path()).unwrap();
         assert_eq!(cfg.net.allow, Some(vec!["global.example".to_string()])); // from global config
         assert_eq!(cfg.net.mode, Some("report".to_string()));
         assert_eq!(cfg.tools.apt, Some(vec!["ripgrep".to_string()]));
@@ -206,14 +207,18 @@ mod tests {
     #[test]
     fn load_config_malformed_is_error() {
         let config_dir = temp_dir();
-        std::fs::write(config_dir.join("config.toml"), "this is = not valid = toml").unwrap();
-        assert!(load_config(&config_dir).is_err());
+        std::fs::write(
+            config_dir.path().join("config.toml"),
+            "this is = not valid = toml",
+        )
+        .unwrap();
+        assert!(load_config(config_dir.path()).is_err());
     }
 
     #[test]
     fn check_blocked_dir_exact_match_only() {
-        let home = temp_dir();
-        let home = home.to_str().unwrap();
+        let home_dir = temp_dir();
+        let home = home_dir.path().to_str().unwrap();
         let blocked = vec!["~".to_string(), "/".to_string()];
 
         // Exact $HOME and exact / are refused.

--- a/src/env.rs
+++ b/src/env.rs
@@ -132,14 +132,14 @@ mod tests {
         let cache = crate::testutil::temp_dir();
 
         // Absent: no mount, and any stale copy is removed.
-        let dst = cache.join("gitconfig");
+        let dst = cache.path().join("gitconfig");
         std::fs::write(&dst, "old").unwrap();
-        assert!(git_config_mount(&home, &cache).is_empty());
+        assert!(git_config_mount(home.path(), cache.path()).is_empty());
         assert!(!dst.exists(), "stale gitconfig copy should be removed");
 
         // Present: copied and mounted.
-        std::fs::write(home.join(".gitconfig"), "[user]\n\tname = X\n").unwrap();
-        let m = git_config_mount(&home, &cache);
+        std::fs::write(home.path().join(".gitconfig"), "[user]\n\tname = X\n").unwrap();
+        let m = git_config_mount(home.path(), cache.path());
         assert_eq!(
             m,
             vec![

--- a/src/net.rs
+++ b/src/net.rs
@@ -342,7 +342,8 @@ mod tests {
 
     #[test]
     fn allowlist_seed_count_and_atomic_add() {
-        let np = NetPolicy::new(&crate::testutil::temp_dir());
+        let dir = crate::testutil::temp_dir();
+        let np = NetPolicy::new(dir.path());
         np.ensure().unwrap();
         np.seed_allowlist_if_absent();
         let base = np.count_domains();
@@ -365,17 +366,22 @@ mod tests {
         let cache = crate::testutil::temp_dir();
         // Install seeds the 11 defaults, then unions the harness domains not already
         // present — api.anthropic.com is a default (no-op); example.test is new.
-        seed_allowlist(&cache, &["api.anthropic.com".into(), "example.test".into()]).unwrap();
-        let np = NetPolicy::new(&cache);
+        seed_allowlist(
+            cache.path(),
+            &["api.anthropic.com".into(), "example.test".into()],
+        )
+        .unwrap();
+        let np = NetPolicy::new(cache.path());
         assert_eq!(np.count_domains(), 12, "11 defaults + 1 new harness domain");
         // Idempotent: re-seeding the same domain adds nothing.
-        seed_allowlist(&cache, &["example.test".into()]).unwrap();
+        seed_allowlist(cache.path(), &["example.test".into()]).unwrap();
         assert_eq!(np.count_domains(), 12);
     }
 
     #[test]
     fn denied_domains_unique_sorted() {
-        let np = NetPolicy::new(&crate::testutil::temp_dir());
+        let dir = crate::testutil::temp_dir();
+        let np = NetPolicy::new(dir.path());
         np.ensure().unwrap();
         std::fs::write(
             &np.deny_log,
@@ -387,7 +393,8 @@ mod tests {
             vec!["evil.com".to_string(), "tracker.io".to_string()]
         );
 
-        let empty = NetPolicy::new(&crate::testutil::temp_dir());
+        let empty_dir = crate::testutil::temp_dir();
+        let empty = NetPolicy::new(empty_dir.path());
         empty.ensure().unwrap();
         assert!(empty.denied_domains().is_empty());
     }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -229,33 +229,38 @@ mod tests {
         let h = claude();
 
         // No host creds: nothing seeded.
-        bootstrap_credentials(&home, &state, &h);
+        bootstrap_credentials(home.path(), state.path(), &h);
         assert!(
-            !state.join(".credentials.json").is_file(),
+            !state.path().join(".credentials.json").is_file(),
             "seeded creds without a host source"
         );
 
         // Host login present + empty store: inherited.
-        std::fs::create_dir_all(home.join(".claude")).unwrap();
-        std::fs::write(home.join(".claude").join(".credentials.json"), "HOST").unwrap();
-        bootstrap_credentials(&home, &state, &h);
+        std::fs::create_dir_all(home.path().join(".claude")).unwrap();
+        std::fs::write(
+            home.path().join(".claude").join(".credentials.json"),
+            "HOST",
+        )
+        .unwrap();
+        bootstrap_credentials(home.path(), state.path(), &h);
         assert_eq!(
-            std::fs::read_to_string(state.join(".credentials.json")).unwrap(),
+            std::fs::read_to_string(state.path().join(".credentials.json")).unwrap(),
             "HOST"
         );
 
         // Container has since logged in: the host seed must not clobber it.
-        std::fs::write(state.join(".credentials.json"), "existing").unwrap();
-        bootstrap_credentials(&home, &state, &h);
+        std::fs::write(state.path().join(".credentials.json"), "existing").unwrap();
+        bootstrap_credentials(home.path(), state.path(), &h);
         assert_eq!(
-            std::fs::read_to_string(state.join(".credentials.json")).unwrap(),
+            std::fs::read_to_string(state.path().join(".credentials.json")).unwrap(),
             "existing"
         );
     }
 
     #[test]
     fn seed_claude_config_json_preserves_login() {
-        let path = temp_dir().join(".claude.json");
+        let dir = temp_dir();
+        let path = dir.path().join(".claude.json");
         std::fs::write(
             &path,
             r#"{"hasCompletedOnboarding":false,"oauthAccount":{"emailAddress":"a@b.c"},"numberOfStartups":1784592922215,"projects":{"/other":{"hasTrustDialogAccepted":true}}}"#,
@@ -292,7 +297,8 @@ mod tests {
 
     #[test]
     fn seed_claude_config_json_fresh() {
-        let path = temp_dir().join(".claude.json");
+        let dir = temp_dir();
+        let path = dir.path().join(".claude.json");
         seed_claude_config_json(&path, "/proj").unwrap();
         let m: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();

--- a/src/run.rs
+++ b/src/run.rs
@@ -585,8 +585,9 @@ mod tests {
 
     // A ContainerConfig fixture whose sandbox has skills/ + settings.json + CLAUDE.md, but
     // no commands/agents dirs or statusline.sh.
-    fn fixture_with_sandbox() -> (ContainerConfig, std::path::PathBuf) {
-        let sandbox = crate::testutil::temp_dir();
+    fn fixture_with_sandbox() -> (ContainerConfig, tempfile::TempDir) {
+        let dir = crate::testutil::temp_dir();
+        let sandbox = dir.path();
         std::fs::create_dir_all(sandbox.join("skills")).unwrap();
         std::fs::write(sandbox.join("settings.json"), "{}").unwrap();
         std::fs::write(sandbox.join("CLAUDE.md"), "guide").unwrap();
@@ -602,7 +603,7 @@ mod tests {
             key: "-proj".into(),
             ..Default::default()
         };
-        (cfg, sandbox)
+        (cfg, dir)
     }
 
     #[test]
@@ -618,15 +619,15 @@ mod tests {
         for want in [
             format!(
                 "{}:/home/dev/.claude/skills",
-                sandbox.join("skills").display()
+                sandbox.path().join("skills").display()
             ),
             format!(
                 "{}:/home/dev/.claude/settings.json",
-                sandbox.join("settings.json").display()
+                sandbox.path().join("settings.json").display()
             ),
             format!(
                 "{}:/home/dev/.claude/CLAUDE.md",
-                sandbox.join("CLAUDE.md").display()
+                sandbox.path().join("CLAUDE.md").display()
             ),
             "/host/history:/home/dev/.claude/projects/-proj".to_string(),
         ] {
@@ -643,9 +644,9 @@ mod tests {
     #[test]
     fn container_run_args_golden() {
         let sandbox = crate::testutil::temp_dir();
-        std::fs::create_dir_all(sandbox.join("skills")).unwrap();
-        std::fs::write(sandbox.join("settings.json"), "{}").unwrap();
-        std::fs::write(sandbox.join("CLAUDE.md"), "guide").unwrap();
+        std::fs::create_dir_all(sandbox.path().join("skills")).unwrap();
+        std::fs::write(sandbox.path().join("settings.json"), "{}").unwrap();
+        std::fs::write(sandbox.path().join("CLAUDE.md"), "guide").unwrap();
 
         let cfg = ContainerConfig {
             engine: "container".into(),
@@ -660,7 +661,7 @@ mod tests {
             project: "/proj".into(),
             key: "-proj".into(),
             state: "/state".into(),
-            sandbox: sandbox.to_string_lossy().into_owned(),
+            sandbox: sandbox.path().to_string_lossy().into_owned(),
             config_dir: "/home/dev/.claude".into(),
             history: "/hist".into(),
             git_mount: vec![
@@ -681,15 +682,15 @@ mod tests {
 
         let skills = format!(
             "{}:/home/dev/.claude/skills",
-            sandbox.join("skills").display()
+            sandbox.path().join("skills").display()
         );
         let settings = format!(
             "{}:/home/dev/.claude/settings.json",
-            sandbox.join("settings.json").display()
+            sandbox.path().join("settings.json").display()
         );
         let guide = format!(
             "{}:/home/dev/.claude/CLAUDE.md",
-            sandbox.join("CLAUDE.md").display()
+            sandbox.path().join("CLAUDE.md").display()
         );
         let expected: Vec<String> = [
             "run",

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -363,17 +363,17 @@ mod tests {
     fn installed_registry_add_update_remove() {
         let dir = temp_dir();
         assert!(
-            read_installed(&dir).is_empty(),
+            read_installed(dir.path()).is_empty(),
             "fresh registry should be empty"
         );
-        assert!(installed_version(&dir, "claude").is_none());
+        assert!(installed_version(dir.path(), "claude").is_none());
 
-        add_installed(&dir, "claude", "v0.2.0").unwrap();
-        add_installed(&dir, "codex", "latest").unwrap();
-        add_installed(&dir, "claude", "v0.3.0").unwrap(); // update in place
+        add_installed(dir.path(), "claude", "v0.2.0").unwrap();
+        add_installed(dir.path(), "codex", "latest").unwrap();
+        add_installed(dir.path(), "claude", "v0.3.0").unwrap(); // update in place
 
         assert_eq!(
-            read_installed(&dir),
+            read_installed(dir.path()),
             vec![
                 InstalledHarness {
                     name: "claude".into(),
@@ -385,11 +385,14 @@ mod tests {
                 },
             ]
         );
-        assert_eq!(installed_version(&dir, "claude").as_deref(), Some("v0.3.0"));
-
-        remove_installed(&dir, "claude").unwrap();
         assert_eq!(
-            read_installed(&dir),
+            installed_version(dir.path(), "claude").as_deref(),
+            Some("v0.3.0")
+        );
+
+        remove_installed(dir.path(), "claude").unwrap();
+        assert_eq!(
+            read_installed(dir.path()),
             vec![InstalledHarness {
                 name: "codex".into(),
                 version: "latest".into()
@@ -400,13 +403,17 @@ mod tests {
     #[test]
     fn read_installed_bare_name_defaults_latest() {
         let dir = temp_dir();
-        std::fs::write(installed_registry_path(&dir), "claude\n").unwrap();
-        assert_eq!(installed_version(&dir, "claude").as_deref(), Some("latest"));
+        std::fs::write(installed_registry_path(dir.path()), "claude\n").unwrap();
+        assert_eq!(
+            installed_version(dir.path(), "claude").as_deref(),
+            Some("latest")
+        );
     }
 
     #[test]
     fn write_alias_block_round_trip() {
-        let path = temp_dir().join(".zshrc");
+        let dir = temp_dir();
+        let path = dir.path().join(".zshrc");
         std::fs::write(&path, "export FOO=1\n").unwrap();
 
         let block = alias_block(std::slice::from_ref(&claude()), "zsh");
@@ -434,8 +441,13 @@ mod tests {
 
     #[test]
     fn write_alias_block_no_spurious_file() {
-        let path = temp_dir().join(".bashrc"); // temp_dir exists; this file does not
+        let dir = temp_dir();
+        let path = dir.path().join(".bashrc");
         write_alias_block(&path, "").unwrap();
+        assert!(
+            dir.path().is_dir(),
+            "the guard must outlive the assert below"
+        );
         assert!(
             !path.exists(),
             "removing a block from an absent file should not create it"
@@ -446,12 +458,12 @@ mod tests {
     fn sync_aliases_manages_existing_and_current_shell() {
         let config_dir = temp_dir();
         let home = temp_dir();
-        let bashrc = home.join(".bashrc");
+        let bashrc = home.path().join(".bashrc");
         std::fs::write(&bashrc, "# bash\n").unwrap(); // exists -> managed
-        let zshrc = home.join(".zshrc"); // current shell -> created
+        let zshrc = home.path().join(".zshrc"); // current shell -> created
 
-        add_installed(&config_dir, "claude", "latest").unwrap();
-        sync_aliases(&config_dir, &home, Some("zsh"), None).unwrap();
+        add_installed(config_dir.path(), "claude", "latest").unwrap();
+        sync_aliases(config_dir.path(), home.path(), Some("zsh"), None).unwrap();
 
         for p in [&bashrc, &zshrc] {
             let data = std::fs::read_to_string(p).unwrap_or_default();
@@ -461,13 +473,13 @@ mod tests {
             );
         }
         assert!(
-            !fish_conf_path(&home, None).exists(),
+            !fish_conf_path(home.path(), None).exists(),
             "fish neither configured nor current shell; leave alone"
         );
 
         // Uninstalling clears the blocks.
-        remove_installed(&config_dir, "claude").unwrap();
-        sync_aliases(&config_dir, &home, Some("zsh"), None).unwrap();
+        remove_installed(config_dir.path(), "claude").unwrap();
+        sync_aliases(config_dir.path(), home.path(), Some("zsh"), None).unwrap();
         assert!(
             !std::fs::read_to_string(&zshrc)
                 .unwrap()
@@ -512,10 +524,10 @@ mod tests {
     fn sync_aliases_writes_and_removes_fish_conf() {
         let config_dir = temp_dir();
         let home = temp_dir();
-        let conf = fish_conf_path(&home, None);
+        let conf = fish_conf_path(home.path(), None);
 
-        add_installed(&config_dir, "claude", "latest").unwrap();
-        sync_aliases(&config_dir, &home, Some("fish"), None).unwrap();
+        add_installed(config_dir.path(), "claude", "latest").unwrap();
+        sync_aliases(config_dir.path(), home.path(), Some("fish"), None).unwrap();
         assert!(
             std::fs::read_to_string(&conf)
                 .unwrap()
@@ -523,12 +535,12 @@ mod tests {
             "fish alias should land in conf.d/vhrn.fish"
         );
         assert!(
-            !home.join(".config/fish/config.fish").exists(),
+            !home.path().join(".config/fish/config.fish").exists(),
             "config.fish is the user's; vhrn must not touch it"
         );
 
-        remove_installed(&config_dir, "claude").unwrap();
-        sync_aliases(&config_dir, &home, Some("fish"), None).unwrap();
+        remove_installed(config_dir.path(), "claude").unwrap();
+        sync_aliases(config_dir.path(), home.path(), Some("fish"), None).unwrap();
         assert!(
             !conf.exists(),
             "uninstall should remove the vhrn-owned file, not blank it"
@@ -540,18 +552,18 @@ mod tests {
         let config_dir = temp_dir();
         let home = temp_dir();
         let xdg = temp_dir();
-        std::fs::create_dir_all(xdg.join("fish")).unwrap(); // fish configured, but not $SHELL
-        let xdg_s = xdg.to_string_lossy().into_owned();
+        std::fs::create_dir_all(xdg.path().join("fish")).unwrap(); // fish configured, but not $SHELL
+        let xdg_s = xdg.path().to_string_lossy().into_owned();
 
-        add_installed(&config_dir, "claude", "latest").unwrap();
-        sync_aliases(&config_dir, &home, Some("zsh"), Some(&xdg_s)).unwrap();
+        add_installed(config_dir.path(), "claude", "latest").unwrap();
+        sync_aliases(config_dir.path(), home.path(), Some("zsh"), Some(&xdg_s)).unwrap();
 
         assert!(
-            xdg.join("fish/conf.d/vhrn.fish").is_file(),
+            xdg.path().join("fish/conf.d/vhrn.fish").is_file(),
             "an existing fish config dir should be managed even when fish isn't $SHELL"
         );
         assert!(
-            !home.join(".config/fish").exists(),
+            !home.path().join(".config/fish").exists(),
             "XDG_CONFIG_HOME must win over ~/.config"
         );
     }
@@ -560,9 +572,9 @@ mod tests {
     fn sync_aliases_no_spurious_fish_conf() {
         let config_dir = temp_dir();
         let home = temp_dir();
-        sync_aliases(&config_dir, &home, Some("fish"), None).unwrap();
+        sync_aliases(config_dir.path(), home.path(), Some("fish"), None).unwrap();
         assert!(
-            !home.join(".config/fish").exists(),
+            !home.path().join(".config/fish").exists(),
             "nothing installed should not conjure a fish config tree"
         );
     }

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,19 +1,14 @@
 //! Shared test helpers, compiled only under `cfg(test)`.
 
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use tempfile::TempDir;
 
-/// A fresh, canonicalized temp dir (the tempfile crate isn't in the budget).
-/// Canonicalized so comparisons mirror the run path's physical cwd — on macOS the
-/// system temp dir lives under the /var -> /private/var symlink.
-pub(crate) fn temp_dir() -> PathBuf {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+/// A fresh temp dir, removed when the returned guard drops. Rooted in the canonicalized
+/// system temp dir so `path()` is physical — on macOS the temp dir lives under the
+/// /var -> /private/var symlink, and `check_blocked_dir` compares against a physical cwd.
+pub(crate) fn temp_dir() -> TempDir {
+    let root = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+    tempfile::Builder::new()
+        .prefix("vhrn-test-")
+        .tempdir_in(root)
         .unwrap()
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("vhrn-test-{}-{n}-{nanos}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::canonicalize(&dir).unwrap()
 }


### PR DESCRIPTION
The hand-rolled helper never cleaned up, leaking a directory per test. Kept as a thin adapter so the canonical root stays in one place.