### PR TITLE
proxy: update go version to 1.26 from 1.23

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -38,15 +38,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Latest stable, not go-version-file: go.mod states the floor, and testing on
+      # it would pin CI to a toolchain that eventually goes end-of-life.
       - uses: actions/setup-go@v7
         with:
-          go-version-file: proxy/go.mod
+          go-version: stable
       - name: Vet and test
         working-directory: proxy
         run: |
           test -z "$(gofmt -l .)" || { echo 'gofmt needed:'; gofmt -l .; exit 1; }
           go vet ./...
           go test ./...
+      # The stdlib is this binary's only dependency, so a toolchain CVE is the only kind
+      # it can have. govulncheck reports the ones actually reachable from our call graph,
+      # which beats the toolchain version as a signal. `go install pkg@version` resolves
+      # outside the module, so it adds nothing to go.mod.
+      - name: Vulnerability scan
+        working-directory: proxy
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          "$(go env GOPATH)/bin/govulncheck" ./...
 
   scripts:
     if: ${{ inputs.run_scripts }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,13 @@ The suite runs per changed component on PRs and in full on master:
 
 - **CLI:** `cargo fmt --all -- --check`, then `cargo clippy --all-targets -- -D warnings`,
   then `cargo test` (fmt runs before clippy).
-- **Proxy:** `cd proxy && gofmt -l . && go vet ./... && go test ./...`.
+- **Proxy:** `cd proxy && gofmt -l . && go vet ./... && go test ./...`, then `govulncheck
+  ./...` (`go install golang.org/x/vuln/cmd/govulncheck@latest`). The stdlib is the only
+  dependency, so a reachable toolchain CVE is the only kind this binary can have — and
+  with no `go.sum` there is no lockfile churn to surface one. The build image and `go.mod`
+  move together on a minor (`golang:1.26` / `go 1.26`) so patches land on their own and a
+  major is a deliberate bump of both; CI runs `go-version: stable`, so it meets the next
+  major before the image does.
 - **Workflows:** `actionlint` (with shellcheck on inline `run:` scripts) validates
   `.github/workflows/**`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Your `~/.agents` is now mounted in the container at `/home/dev/.agents`, for every
+- `~/.agents` is now mounted in the container at `/home/dev/.agents`, for every
   harness. It is the vendor-neutral config dir agent tools converged on so portable
   configuration — a skill library, today — is installed once rather than once per vendor
   directory. The whole tree is carried in, so a path an agent starts reading later needs no

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,9 @@
 # Build the egress proxy as a static binary and ship it in scratch — no shell,
 # no userland, minimal CVE surface for the component that enforces the boundary.
-FROM golang:1.23 AS build
+# Minor pin, in lockstep with go.mod: patch releases and their security fixes arrive on
+# their own, a major is a deliberate bump of both so language semantics never shift
+# unreviewed. govulncheck in CI is the alarm if this is left to go end-of-life.
+FROM golang:1.26 AS build
 WORKDIR /src
 # No third-party modules, so go.mod alone is enough — there is no go.sum to fetch.
 COPY go.mod ./

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,3 +1,3 @@
 module vhrn/proxy
 
-go 1.23
+go 1.26


### PR DESCRIPTION
docs: fix wording in changelog