### PR TITLE
cli: stop seeding trust and onboarding into .claude.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,14 @@ Core behavioral invariants — keep these intact:
 - **Login/state persists via a container-owned store, not the disposable copy.**
   `~/.cache/vhrn/state/<harness>/` is mounted as the harness's config dir
   (`CLAUDE_CONFIG_DIR` for claude). Host credentials are copied in **only when the store is
-  empty** (bootstrap-only — an in-container login is never overwritten); `.claude.json` is
-  merged in place for onboarding + this project's trust without touching `oauthAccount` or
-  other projects. The disposable synced config, the container guide, and the
-  `projects/<key>` history layer on top as **nested** mounts, so the config sync can never
-  reach `state/`. `.claude.json` must sit in a real directory mount (Claude rewrites it via
-  a backup file), never a single-file mount.
+  empty** (bootstrap-only — an in-container login is never overwritten). Nothing else in the
+  store is ever written by vhrn: onboarding and per-project trust belong to the agent, so the
+  answer given in the container is the one that persists — **do not reintroduce seeding of
+  `hasTrustDialogAccepted`**, which made untrusting a project impossible and handed a repo's
+  own `.claude/skills` their `allowed-tools` grants unasked. The disposable synced config, the
+  container guide, and the `projects/<key>` history layer on top as **nested** mounts, so the
+  config sync can never reach `state/`. `.claude.json` must sit in a real directory mount
+  (Claude rewrites it via a backup file), never a single-file mount.
 - **The disposable config copy (`~/.cache/vhrn/sandbox/<harness>`) is re-synced from
   `~/.claude` every run** (`rsync -aL --delete`, `cp -RL` fallback), so edits there are wiped
   — change `~/.claude` instead. Deleting the host source removes the copy too, so config the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- vhrn no longer decides for you whether a project is trusted. It used to write
+  `hasTrustDialogAccepted` into the container's `.claude.json` before every launch, so the
+  trust dialog never appeared — and untrusting a folder from inside the container was undone
+  on the next run, with no way to make it stick. That also meant a repo's own
+  `.claude/skills` got their `allowed-tools` grants without you ever being asked.
+
+  You will now see the trust prompt once per project, and the answer persists. On a config
+  store that has never been used you will also see the one-time onboarding screen.
+  Existing stores keep every trust answer already recorded in them — nothing is reset.
+
 - The disposable config copy moved from `~/.cache/vhrn/sandbox/` to
   `~/.cache/vhrn/sandbox/<harness>/`, so one harness's sync can never delete files under a
   running container of another. The old directory is left where it is; it is derived state

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pedantic = "warn"
 anyhow = "1.0.104"
 hex = "0.4.3"
 serde = { version = "1.0.229", features = ["derive"] }
-serde_json = { version = "1.0.151", features = ["arbitrary_precision"] }
+serde_json = "1.0.151"
 sha2 = "0.11.0"
 signal-hook = "0.4.4"
 toml = "1.1.3"

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -22,8 +22,6 @@ pub(crate) struct Harness {
     pub sync_dirs: Vec<String>, // disposable synced subdirs, e.g. skills/commands/agents
     pub sync_files: Vec<String>, // disposable synced files, e.g. settings.json/statusline.sh
     pub credentials: Vec<String>, // state_dir-relative bootstrap-only files
-    pub config_json: String, // state_dir-relative login/onboarding/trust file
-    pub seed_trust: bool,  // pre-seed onboarding + per-project trust into config_json
 }
 
 /// The built-in registry. Only claude exists today; the struct shape is what a
@@ -47,8 +45,6 @@ fn registry() -> Vec<Harness> {
         sync_dirs: vec!["skills".into(), "commands".into(), "agents".into()],
         sync_files: vec!["settings.json".into(), "statusline.sh".into()],
         credentials: vec![".credentials.json".into()],
-        config_json: ".claude.json".into(),
-        seed_trust: true,
     }]
 }
 

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -1,9 +1,9 @@
 //! The container-owned state store and the disposable config sync. `state/<harness>/` is
 //! the persistent store mounted as the container's config dir; host credentials seed it
-//! bootstrap-only (an in-container login is never clobbered), and `.claude.json` is merged
-//! in place to complete onboarding + trust this project without touching
-//! `oauthAccount`/other projects. The sandbox sync + container guide are re-derived each
-//! run and layered on top as nested mounts.
+//! bootstrap-only (an in-container login is never clobbered). Everything else in the store
+//! belongs to the agent — onboarding and per-project trust included — so a decision made
+//! in the container is the one that survives. The sandbox sync + container guide are
+//! re-derived each run and layered on top as nested mounts.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -20,25 +20,13 @@ fn host_state_dir(cache: &Path, harness: &str) -> PathBuf {
     cache.join("state").join(harness)
 }
 
-/// Ready the persistent store before launch and return its path: ensure the dir,
-/// bootstrap credentials from the host once, and seed onboarding + this project's
-/// trust into the config JSON.
-pub(crate) fn prepare_state(
-    home: &Path,
-    cache: &Path,
-    h: &Harness,
-    project: &str,
-) -> Result<PathBuf> {
+/// Ready the persistent store before launch and return its path: ensure the dir and
+/// bootstrap credentials from the host once.
+pub(crate) fn prepare_state(home: &Path, cache: &Path, h: &Harness) -> Result<PathBuf> {
     let state = host_state_dir(cache, &h.name);
     std::fs::create_dir_all(&state)?;
     set_mode(&state, 0o700)?;
     bootstrap_credentials(home, &state, h);
-    if h.seed_trust
-        && !h.config_json.is_empty()
-        && let Err(e) = seed_claude_config_json(&state.join(&h.config_json), project)
-    {
-        warn!("could not seed {}: {e}", h.config_json);
-    }
     Ok(state)
 }
 
@@ -61,52 +49,6 @@ fn bootstrap_credentials(home: &Path, state: &Path, h: &Harness) {
         }
         let _ = set_mode(&dst, 0o600); // credentials stay private
     }
-}
-
-/// Ensure the container-owned config JSON has onboarding completed and this project
-/// pre-trusted, without disturbing anything the container wrote (login/oauthAccount, other
-/// projects). Numbers are preserved exactly (`arbitrary_precision`), and an unparseable
-/// container-owned file is left untouched rather than clobbered.
-fn seed_claude_config_json(path: &Path, project: &str) -> Result<()> {
-    use serde_json::{Map, Value};
-
-    let mut m: Map<String, Value> = match std::fs::read(path) {
-        Ok(data) if !data.is_empty() => match serde_json::from_slice::<Value>(&data) {
-            Ok(Value::Object(map)) => map,
-            _ => return Ok(()), // unparseable / not an object: leave the container's file untouched
-        },
-        _ => Map::new(), // absent or empty: fresh
-    };
-
-    m.entry("hasCompletedOnboarding")
-        .or_insert(Value::Bool(true));
-
-    let projects = m
-        .entry("projects")
-        .or_insert_with(|| Value::Object(Map::new()));
-    if !projects.is_object() {
-        *projects = Value::Object(Map::new());
-    }
-    let projects = projects.as_object_mut().unwrap();
-
-    let proj = projects
-        .entry(project)
-        .or_insert_with(|| Value::Object(Map::new()));
-    if !proj.is_object() {
-        *proj = Value::Object(Map::new());
-    }
-    let proj = proj.as_object_mut().unwrap();
-    proj.insert("hasTrustDialogAccepted".to_string(), Value::Bool(true));
-    proj.insert(
-        "hasCompletedProjectOnboarding".to_string(),
-        Value::Bool(true),
-    );
-
-    let mut out = serde_json::to_string_pretty(&Value::Object(m))?;
-    out.push('\n');
-    std::fs::write(path, out)?;
-    set_mode(path, 0o600)?;
-    Ok(())
 }
 
 /// Copy src to dst, following symlinks in src (like cp -L), creating parents.
@@ -307,51 +249,21 @@ mod tests {
     }
 
     #[test]
-    fn seed_claude_config_json_preserves_login() {
-        let dir = temp_dir();
-        let path = dir.path().join(".claude.json");
-        std::fs::write(
-            &path,
-            r#"{"hasCompletedOnboarding":false,"oauthAccount":{"emailAddress":"a@b.c"},"numberOfStartups":1784592922215,"projects":{"/other":{"hasTrustDialogAccepted":true}}}"#,
-        )
-        .unwrap();
+    fn prepare_state_leaves_the_config_json_alone() {
+        let home = temp_dir();
+        let cache = temp_dir();
+        let h = claude();
 
-        seed_claude_config_json(&path, "/proj").unwrap();
-        let raw = std::fs::read_to_string(&path).unwrap();
-        // Big integers survive without float mangling.
-        assert!(
-            raw.contains("1784592922215"),
-            "large number not preserved:\n{raw}"
-        );
+        // A container-owned file that has the project explicitly *untrusted*.
+        let state = cache.path().join("state").join("claude");
+        std::fs::create_dir_all(&state).unwrap();
+        let path = state.join(".claude.json");
+        let before = r#"{"projects":{"/proj":{"hasTrustDialogAccepted":false}}}"#;
+        std::fs::write(&path, before).unwrap();
 
-        let m: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(
-            m.get("oauthAccount").is_some(),
-            "oauthAccount (login) dropped"
-        );
-        assert_eq!(
-            m["hasCompletedOnboarding"], false,
-            "existing onboarding overwritten"
-        );
-        assert!(
-            m["projects"].get("/other").is_some(),
-            "existing project trust dropped"
-        );
-        assert_eq!(m["projects"]["/proj"]["hasTrustDialogAccepted"], true);
-        assert_eq!(
-            m["projects"]["/proj"]["hasCompletedProjectOnboarding"],
-            true
-        );
-    }
+        prepare_state(home.path(), cache.path(), &h).unwrap();
 
-    #[test]
-    fn seed_claude_config_json_fresh() {
-        let dir = temp_dir();
-        let path = dir.path().join(".claude.json");
-        seed_claude_config_json(&path, "/proj").unwrap();
-        let m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(m["hasCompletedOnboarding"], true);
-        assert_eq!(m["projects"]["/proj"]["hasTrustDialogAccepted"], true);
+        // The agent owns this file: an untrust made in the container must survive.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -70,7 +70,7 @@ pub(crate) fn look_path(name: &str) -> bool {
 }
 
 /// Set a path's unix permission bits (safe — the crate forbids unsafe). Used for the
-/// world-writable policy dir/log and the private creds/.claude.json.
+/// world-writable policy dir/log and the private state dir and credentials.
 pub(crate) fn set_mode(path: &Path, mode: u32) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
@@ -401,7 +401,7 @@ fn prepare_container(h: &Harness) -> Result<ContainerConfig> {
     let history = host_config.join("projects").join(&key);
 
     // The persistent, container-owned store — login/credentials/onboarding live here.
-    let state = crate::persist::prepare_state(&home, &cache, h, &project_s)?;
+    let state = crate::persist::prepare_state(&home, &cache, h)?;
 
     std::fs::create_dir_all(&sandbox)?;
     std::fs::create_dir_all(&history)?;


### PR DESCRIPTION
hasTrustDialogAccepted was rewritten every run, so untrusting a project in the container never stuck. The agent owns the file now.