### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-29
+
 ### Added
 
 - **OpenAI Codex is now a harness.** `vhrn install codex`, then `codex` (or `vhrn codex`)
@@ -185,7 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `toolchains.tools` derived image rebuilds when its harness image updates (the base image
   identity is folded into the toolchain hash), so `vhrn update` no longer keeps the old agent.
 
-[unreleased]: https://github.com/aravind-n/vhrn/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/aravind-n/vhrn/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/aravind-n/vhrn/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/aravind-n/vhrn/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/aravind-n/vhrn/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/aravind-n/vhrn/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vhrn"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhrn"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 description = "Run coding agents in a filesystem- and network-jailed container"


### PR DESCRIPTION
Cuts 0.4.0: promotes the `Unreleased` changelog section, bumps `Cargo.toml`, refreshes `Cargo.lock`.

Minor rather than patch — two things a user must act on:

- **fish alias moved to `conf.d/vhrn.fish`.** The old `# >>> vhrn managed aliases >>>` block in
  `config.fish` is left in place and must be deleted by hand, or the alias is defined twice.
- **The disposable config copy moved** to `~/.cache/vhrn/sandbox/<harness>/`, leaving stray
  top-level files in the old directory.

Headline of the release itself is the codex harness, the `~/.agents` mount, and dropping the
`hasTrustDialogAccepted` seeding.

Gate run locally on the release commit: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (97 passed).

Tag `v0.4.0` goes on the merge commit once this lands.